### PR TITLE
Allow to pass format as a custom array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to `headless-browser-client-php` will be documented in this file
+## 3.0.0 - 2024-07-25
+ - format can be set to null
+ - add width and height properties
 
 ## 2.0.0 - 2024-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 All notable changes to `headless-browser-client-php` will be documented in this file
-## 3.0.0 - 2024-07-25
- - format can be set to null
- - add width and height properties
+
+## 3.0.0 - 2024-11-14
+ - PDF format can be set to null
+ - Add width and height properties for PDF
 
 ## 2.0.0 - 2024-07-25
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,23 @@ $headlessBrowser = new \AirLST\HeadlessBrowserClient\AirlstHeadlessBrowser('api-
 
 ### Generate PDF from HTML
 
+#### Using standard format
 ```php
 $headlessBrowser->pdf(
     '<p>html</p>', // html content
-    'A4', // page size
     [10, 10, 10, 10] // margins
+    'A4', // page size
+);
+```
+
+#### Using custom size
+```php
+$headlessBrowser->pdf(
+    '<p>html</p>', // html content
+    [10, 10, 10, 10] // margins
+    null, // Page size must be null otherwise it will override the custom width and height
+    '80mm', // width
+    '60mm', // height
 );
 ```
 

--- a/src/AirlstHeadlessBrowser.php
+++ b/src/AirlstHeadlessBrowser.php
@@ -22,8 +22,8 @@ final readonly class AirlstHeadlessBrowser implements HeadlessBrowser
     #[Override]
     public function pdf(
         string $html,
-        string $format = 'A4',
         array $margins = [10, 10, 10, 10],
+        ?string $format = null,
         ?string $width = null,
         ?string $height = null,
     ): Response {

--- a/src/AirlstHeadlessBrowser.php
+++ b/src/AirlstHeadlessBrowser.php
@@ -22,7 +22,7 @@ final readonly class AirlstHeadlessBrowser implements HeadlessBrowser
     #[Override]
     public function pdf(
         string $html,
-        string $format = 'A4',
+        array|string $format = 'A4',
         array $margins = [10, 10, 10, 10]
     ): Response {
         $request = $this->prepareRequest('/pdf', [

--- a/src/AirlstHeadlessBrowser.php
+++ b/src/AirlstHeadlessBrowser.php
@@ -22,13 +22,17 @@ final readonly class AirlstHeadlessBrowser implements HeadlessBrowser
     #[Override]
     public function pdf(
         string $html,
-        array|string $format = 'A4',
-        array $margins = [10, 10, 10, 10]
+        string $format = 'A4',
+        array $margins = [10, 10, 10, 10],
+        ?string $width = null,
+        ?string $height = null,
     ): Response {
         $request = $this->prepareRequest('/pdf', [
             'html' => $html,
             'format' => $format,
             'margins' => $margins,
+            'width' => $width,
+            'height' => $height,
         ]);
 
         $response = $this->client->sendRequest($request);

--- a/src/HeadlessBrowser.php
+++ b/src/HeadlessBrowser.php
@@ -6,7 +6,7 @@ namespace Airlst\HeadlessBrowserClient;
 
 interface HeadlessBrowser
 {
-    public function pdf(string $html, string $format = 'A4', array $margins = [10, 10, 10, 10], ?string $width = null, ?string $height = null): Response;
+    public function pdf(string $html, array $margins = [10, 10, 10, 10], ?string $format = null, ?string $width = null, ?string $height = null): Response;
 
     public function jpeg(string $html, int $quality = 75): Response;
 }

--- a/src/HeadlessBrowser.php
+++ b/src/HeadlessBrowser.php
@@ -6,7 +6,7 @@ namespace Airlst\HeadlessBrowserClient;
 
 interface HeadlessBrowser
 {
-    public function pdf(string $html, string $format = 'A4', array $margins = [10, 10, 10, 10]): Response;
+    public function pdf(string $html, string $format = 'A4', array $margins = [10, 10, 10, 10], ?string $width = null, ?string $height = null): Response;
 
     public function jpeg(string $html, int $quality = 75): Response;
 }

--- a/tests/AirlstHeadlessBrowserTest.php
+++ b/tests/AirlstHeadlessBrowserTest.php
@@ -87,6 +87,23 @@ final class AirlstHeadlessBrowserTest extends TestCase
         $this->assertSame('http://example.com/jpeg', $jpeg->temporaryUrl());
     }
 
+    public function testAcceptsCustomSize(): void
+    {
+        $client = Mockery::mock(ClientInterface::class);
+        $client->shouldReceive('sendRequest')
+            ->once()
+            ->withArgs(function (RequestInterface $request): bool {
+                $inputs = json_decode($request->getBody()->getContents(), true);
+
+                return $inputs['format'] === ['customWidth', 'customHeight'];
+            })
+            ->andReturn(new Response(200, [], json_encode(['temporary_url' => 'http://example.com/pdf'])));
+
+        $pdf = (new AirlstHeadlessBrowser('api-key', $client))->pdf('<p>html</p>', ['customWidth', 'customHeight'], [5, 5, 5, 5]);
+
+        $this->assertSame('http://example.com/pdf', $pdf->temporaryUrl());
+    }
+
     public function testImplementsHeadlessBrowser(): void
     {
         $this->assertTrue(

--- a/tests/AirlstHeadlessBrowserTest.php
+++ b/tests/AirlstHeadlessBrowserTest.php
@@ -43,11 +43,11 @@ final class AirlstHeadlessBrowserTest extends TestCase
                     return false;
                 }
 
-                return $request->getBody()->getContents() === '{"html":"<p>html<\/p>","format":"A3","margins":[5,5,5,5],"width":null,"height":null}';
+                return $request->getBody()->getContents() === '{"html":"<p>html<\/p>","format":"A4","margins":[5,5,5,5],"width":null,"height":null}';
             })
             ->andReturn(new Response(200, [], json_encode(['temporary_url' => 'http://example.com/pdf'])));
 
-        $pdf = (new AirlstHeadlessBrowser('api-key', $client))->pdf('<p>html</p>', 'A3', [5, 5, 5, 5]);
+        $pdf = (new AirlstHeadlessBrowser('api-key', $client))->pdf('<p>html</p>', [5, 5, 5, 5], 'A4');
 
         $this->assertSame('http://example.com/pdf', $pdf->temporaryUrl());
     }

--- a/tests/AirlstHeadlessBrowserTest.php
+++ b/tests/AirlstHeadlessBrowserTest.php
@@ -43,7 +43,7 @@ final class AirlstHeadlessBrowserTest extends TestCase
                     return false;
                 }
 
-                return $request->getBody()->getContents() === '{"html":"<p>html<\/p>","format":"A3","margins":[5,5,5,5]}';
+                return $request->getBody()->getContents() === '{"html":"<p>html<\/p>","format":"A3","margins":[5,5,5,5],"width":null,"height":null}';
             })
             ->andReturn(new Response(200, [], json_encode(['temporary_url' => 'http://example.com/pdf'])));
 
@@ -95,11 +95,11 @@ final class AirlstHeadlessBrowserTest extends TestCase
             ->withArgs(function (RequestInterface $request): bool {
                 $inputs = json_decode($request->getBody()->getContents(), true);
 
-                return $inputs['format'] === ['customWidth', 'customHeight'];
+                return $inputs['width'] === 'customWidth' && $inputs['height'] === 'customHeight';
             })
             ->andReturn(new Response(200, [], json_encode(['temporary_url' => 'http://example.com/pdf'])));
 
-        $pdf = (new AirlstHeadlessBrowser('api-key', $client))->pdf('<p>html</p>', ['customWidth', 'customHeight'], [5, 5, 5, 5]);
+        $pdf = (new AirlstHeadlessBrowser('api-key', $client))->pdf('<p>html</p>', width: 'customWidth', height: 'customHeight', margins: [5, 5, 5, 5]);
 
         $this->assertSame('http://example.com/pdf', $pdf->temporaryUrl());
     }


### PR DESCRIPTION
### Pull Request Description

#### Summary
This PR introduces updates to the `AirlstHeadlessBrowser` class to enhance flexibility in PDF generation.

#### Changes Made
**`AirlstHeadlessBrowser::pdf()` Method Update**:
   - Modified the `pdf` method signature to accept custom `null|string` `$width` and `$height` parameters.
   - This allows the method to handle custom formats, such as custom width and height, enabling more versatile PDF generation options.

#### Motivation
These changes allow for more flexibility in generating PDFs with custom dimensions, catering to use cases where a standard A4 format is not suitable.

#### Testing
- Verified that the custom format parameters are correctly processed in the request body and that the response handling is accurate.